### PR TITLE
spec: Obsolete cuda-nvidia-kmod-common

### DIFF
--- a/nvidia-kmod-common.spec
+++ b/nvidia-kmod-common.spec
@@ -56,6 +56,7 @@ BuildRequires:  systemd
 Requires:       grubby
 Requires:       nvidia-kmod = %{?epoch:%{epoch}:}%{version}
 Provides:       nvidia-kmod-common = %{?epoch:%{epoch}:}%{version}
+Obsoletes:      cuda-nvidia-kmod-common
 
 %description
 This package provides the common files required by all NVIDIA kernel module


### PR DESCRIPTION
There is a cuda-nvidia-kmod-common package in the cuda repository that
provides 'nvidia-kmod-common >= 1:352'.
The >= makes this especially tricky and rpm ignores the fact that the
package itself is in a much lower version.