### PR TITLE
fix: use driver default pcie RTD3 power management

### DIFF
--- a/nvidia.conf
+++ b/nvidia.conf
@@ -19,6 +19,5 @@ softdep nvidia post: nvidia-uvm
 # Enable complete power management. From:
 # file:///usr/share/doc/nvidia-driver/html/powermanagement.html
 
-options nvidia NVreg_DynamicPowerManagement=0x02
 options nvidia NVreg_EnableS0ixPowerManagement=1
 options nvidia NVreg_PreserveVideoMemoryAllocations=1


### PR DESCRIPTION
Recently discovered that forcibly setting `NVreg_DynamicPowerManagement=0x02` caused Ampere Optimus GPUs to be stuck in D0 state causing them to drain much more battery than desired.

At least as of nvidia driver 560/565, the default value of `0x03` should put supported cards into the correct power management mode.

I was able to confirm removing this one setting fixed RTD3 PM on at least 3050ti mobile systems.

I hope this patch is helpful. In the meantime Universal Blue has applied the patch in our downstream use of the negativo17 nvidia driver packages.

https://github.com/ublue-os/hwe/issues/290

Thanks for all work work on negativo17 repos!