### PR TITLE
fix: remove nvidia module probes it again

### DIFF
--- a/60-nvidia.rules
+++ b/60-nvidia.rules
@@ -2,7 +2,7 @@
 # In case the DDX is not started, the device nodes are never created, so call
 # nvidia-modprobe in the udev rules to cover the Wayland/EGLStream and compute
 # case without a started display.
-KERNEL=="nvidia", RUN+="/usr/bin/nvidia-modprobe"
+ACTION=="add|bind", KERNEL=="nvidia", RUN+="/usr/bin/nvidia-modprobe"
 
 # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
 ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"


### PR DESCRIPTION
`nvidia-modprobe` will create device file and load nvidia driver, it seems to be launched only if `add|bind` to prevent `remove/unbind` triggers it.